### PR TITLE
Fixed returns on failed stacks in sm_execution_manager.py - Issue #4

### DIFF
--- a/source/manifest/sm_execution_manager.py
+++ b/source/manifest/sm_execution_manager.py
@@ -153,7 +153,7 @@ class SMExecutionManager:
                 if operation_status_flag:
                     self.logger.info("Continuing...")
                 else:
-                    return operation_status_flag
+                    return operation_status_flag, False
 
                 # Compare template copy - START
                 self.logger.info("Comparing the template of the StackSet:"
@@ -173,7 +173,7 @@ class SMExecutionManager:
                     self.logger.error("TemplateURL in state machine input "
                                       "is empty. Check state_machine_event"
                                       ":{}".format(sm_input))
-                    return False
+                    return False, False
 
                 cfn_template_file = tempfile.mkstemp()[1]
                 with open(cfn_template_file, "w") as f:


### PR DESCRIPTION
#4 

Added 2nd "False" to returns in compare_template_and_params() function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
