### PR TITLE
Add support for CodeCommit configuration source

### DIFF
--- a/deployment/custom-control-tower-initiation.template
+++ b/deployment/custom-control-tower-initiation.template
@@ -27,6 +27,24 @@ Parameters:
     Description: (Not required if Pipeline Approval Stage = 'No') Email for notifying that the CustomControlTower pipeline is waiting for an Approval
     Type: String
 
+  CodeCommitConfigurationSource:
+    Description: Use AWS CodeCommit as the configuration source?
+    AllowedValues:
+      - 'Yes'
+      - 'No'
+    Default: 'No'
+    Type: String
+
+  CodeCommitRepositoryName:
+    Description: (Not required if CodeCommit Configuration Source = 'No') Name of CodeCommit repository that will contain custom Control Tower configuration
+    Default: custom-control-tower-configuration
+    Type: String
+
+  CodeCommitBranchName:
+    Description: (Not required if CodeCommit Configuration Source = 'No') Name of branch in CodeCommit repository that will contain custom Control Tower configuration
+    Default: master
+    Type: String
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -35,12 +53,24 @@ Metadata:
       Parameters:
       - PipelineApprovalStage
       - PipelineApprovalEmail
+      - CodeCommitConfigurationSource
+    - Label:
+        default: CodeCommit Configuration (Used only if CodeCommitConfigurationSource = 'Yes')
+      Parameters:
+      - CodeCommitRepositoryName
+      - CodeCommitBranchName
 
     ParameterLabels:
       PipelineApprovalStage:
         default: Pipeline Approval Stage
       PipelineApprovalEmail:
         default: Pipeline Approval Email Address
+      CodeCommitConfigurationSource:
+        default: CodeCommit Configuration Source
+      CodeCommitRepositoryName:
+        default: CodeCommit Repository Name
+      CodeCommitBranchName:
+        default: CodeCommit Branch Name
 
 Mappings:
   BucketConfiguration:
@@ -83,6 +113,7 @@ Mappings:
 Conditions:
   IsPipelineApprovalStageCondition: !Equals [!Ref PipelineApprovalStage, 'Yes']
   IsBuildCustomControlTowerCondition: !Equals [!FindInMap [AutoBuild, CustomControlTower, Flag], 'Yes']
+  IsCodeCommitConfigurationSource: !Equals [!Ref CodeCommitConfigurationSource, 'Yes']
 
 Resources:
 
@@ -191,6 +222,13 @@ Resources:
             Action: s3:DeleteBucket
             Resource: !Sub "arn:aws:s3:::${CustomControlTowerS3AccessLogsBucket}"
 
+  CustomControlTowerCodeCommit:
+    Type: AWS::CodeCommit::Repository
+    Condition: IsCodeCommitConfigurationSource
+    Properties:
+      RepositoryDescription: Configuration for Customizations for AWS Control Tower solution
+      RepositoryName: !Ref CodeCommitRepositoryName
+
   CustomControlTowerCodePipelineRole:
     Type: AWS::IAM::Role
     Metadata:
@@ -281,15 +319,25 @@ Resources:
           Actions:
             - Name: Source
               ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: S3
+                !If
+                  - IsCodeCommitConfigurationSource
+                  - Category: Source
+                    Owner: AWS
+                    Version: "1"
+                    Provider: CodeCommit
+                  - Category: Source
+                    Owner: AWS
+                    Version: "1"
+                    Provider: S3
               OutputArtifacts:
                 - Name: SourceApp
               Configuration:
-                S3Bucket: !Ref CustomControlTowerPipelineS3Bucket
-                S3ObjectKey: !FindInMap [BucketConfiguration, CustomControlTowerPipelineS3TriggerKey, Name]
+                !If
+                  - IsCodeCommitConfigurationSource
+                  - RepositoryName: !GetAtt CustomControlTowerCodeCommit.Name
+                    BranchName: !Ref CodeCommitBranchName
+                  - S3Bucket: !Ref CustomControlTowerPipelineS3Bucket
+                    S3ObjectKey: !FindInMap [BucketConfiguration, CustomControlTowerPipelineS3TriggerKey, Name]
               RunOrder: 1
         - Name: Build
           Actions:
@@ -2644,6 +2692,54 @@ Resources:
       Enabled: true
       EventSourceArn: !GetAtt CustomControlTowerLEFIFOQueue.Arn
       FunctionName: !Ref CustomControlTowerLELambda
+
+  CustomControlTowerPipelineTriggerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "events.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+  CustomControlTowerCodeCommitPipelineTriggerCWEventRule:
+    Type: AWS::Events::Rule
+    Condition: IsCodeCommitConfigurationSource
+    Properties:
+      Description: Custom Control Tower - Rule for triggering CodePipeline from CodeCommit
+      EventPattern:
+        {
+          "source": [
+            "aws.codecommit"
+          ],
+          "detail-type": [
+            "CodeCommit Repository State Change"
+          ],
+          "resources": [
+            !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepositoryName}"
+          ],
+          "detail": {
+            "event": [
+              "referenceCreated",
+              "referenceUpdated"
+            ],
+            "referenceType": [
+              "branch"
+            ],
+            "referenceName": [
+              !Ref CodeCommitBranchName
+            ]
+          }
+        }
+      State: ENABLED
+      Targets:
+        - Arn: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${CustomControlTowerCodePipeline}"
+          Id: "CustomControlTower_Pipeline_Trigger"
+          RoleArn: !GetAtt CustomControlTowerPipelineTriggerRole.Arn
 
   # Cloudwatch Event Rule for Lifecycle Event (LE): triggered by LE events and send events to SQS
   CustomControlTowerLECWEventRule:


### PR DESCRIPTION
This pull request adds optional support for using AWS CodeCommit instead of Amazon S3 as the configuration source. This behaviour is enabled by a new CloudFormation parameter. Additional parameters optionally allow the CodeCommit repository name and branch name to be customised.

If this pull request is accepted, appendix B of the [deployment guide](https://docs.aws.amazon.com/solutions/latest/customizations-for-aws-control-tower/welcome.html) should be updated. The existing directions for manually enabling a CodeCommit configuration source via the AWS Management Console should be removed and replaced with documentation of the new CloudFormation parameters that enable the use of CodeCommit instead of S3.

As a further enhancement, the deployment process could be extended to copy the example configuration (the contents of `_custom-control-tower-configuration.zip`) to the template output bucket. Then the `Code` parameter of the `CustomControlTowerCodeCommit` resource could be set to that bucket location to prepopulate the new CodeCommit repository with these files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.