### PR TITLE
StackSetCodeBuildRole permissions

### DIFF
--- a/deployment/custom-control-tower-initiation.template
+++ b/deployment/custom-control-tower-initiation.template
@@ -634,7 +634,12 @@ Resources:
                   - ec2:CreateKeyPair
                 Resource:
                   - '*'
-
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStackSet
+                  - cloudformation:ListStackSetOperations
+                  - cloudformation:ListStackInstances
+                Resource: '*'
   StackSetCodeBuild:
       Type: AWS::CodeBuild::Project
       DependsOn: CustomControlTowerDeploymentLambda

--- a/deployment/custom-control-tower-initiation.template
+++ b/deployment/custom-control-tower-initiation.template
@@ -634,12 +634,7 @@ Resources:
                   - ec2:CreateKeyPair
                 Resource:
                   - '*'
-              - Effect: Allow
-                Action:
-                  - cloudformation:DescribeStackSet
-                  - cloudformation:ListStackSetOperations
-                  - cloudformation:ListStackInstances
-                Resource: '*'
+
   StackSetCodeBuild:
       Type: AWS::CodeBuild::Project
       DependsOn: CustomControlTowerDeploymentLambda

--- a/source/manifest/manifest_parser.py
+++ b/source/manifest/manifest_parser.py
@@ -152,10 +152,6 @@ class StackSetParser:
         ou_ids_manifest = []
         # convert OU Name to OU IDs
         for ou_name in resource.deploy_to_ou:
-
-            if ou_name == 'Root':
-                accounts_in_ou.extend(accounts_in_all_ous)
-
             ou_id = [value for key, value in ou_name_to_id_map.items()
                      if ou_name == key]
             ou_ids_manifest.extend(ou_id)
@@ -406,3 +402,4 @@ class StackSetParser:
             )
             ssm_input_map.update(ssm_value)
         return ssm_input_map
+

--- a/source/manifest/manifest_parser.py
+++ b/source/manifest/manifest_parser.py
@@ -152,6 +152,10 @@ class StackSetParser:
         ou_ids_manifest = []
         # convert OU Name to OU IDs
         for ou_name in resource.deploy_to_ou:
+
+            if ou_name == 'Root':
+                accounts_in_ou.extend(accounts_in_all_ous)
+
             ou_id = [value for key, value in ou_name_to_id_map.items()
                      if ou_name == key]
             ou_ids_manifest.extend(ou_id)

--- a/source/state_machine_handler.py
+++ b/source/state_machine_handler.py
@@ -892,11 +892,7 @@ class ServiceControlPolicy(object):
         self.logger.info("Looking up the OU Id for OUName: {} with nested"
                          " ou delimiter: {}".format(nested_ou_name,
                                                     delimiter))
-        if nested_ou_name == 'Root':
-            self.logger.info("We want to apply this SCP to the Root level")
-            return root_id
-        else:
-            return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
+        return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
 
     def _get_ou_id(self, org, parent_id, nested_ou_name, delimiter):
         nested_ou_name_list = self._empty_separator_handler(
@@ -1187,3 +1183,4 @@ class StackSetSMRequests(object):
         _seconds = randint(60, 840)
         time.sleep(_seconds)
         return self.event
+

--- a/source/state_machine_handler.py
+++ b/source/state_machine_handler.py
@@ -892,7 +892,11 @@ class ServiceControlPolicy(object):
         self.logger.info("Looking up the OU Id for OUName: {} with nested"
                          " ou delimiter: {}".format(nested_ou_name,
                                                     delimiter))
-        return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
+        if nested_ou_name == 'Root':
+            self.logger.info("We want to apply this SCP to the Root level")
+            return root_id
+        else:
+            return self._get_ou_id(org, root_id, nested_ou_name, delimiter)
 
     def _get_ou_id(self, org, parent_id, nested_ou_name, delimiter):
         nested_ou_name_list = self._empty_separator_handler(


### PR DESCRIPTION
The Codepipline step 'CloudformationResource' is unable to compare the currently deployed stackset instances with the cloudformation templates supplied in the custom-control-tower-configuration.zip file.

The sm_execution_manager.py script fails to execute the 'compare_template_and_params()' function. A cloudtrail event 'DescribeStackSet' with Error code AccessDenied is logged.

This is because the IAM Role 'StackSetCodeBuildRole' is lacking permissions for this action.
The pull request adds the necessary permissions.

As this allows the 'compare_template_and_params()' function to work correctly, the deployed stacks under a stackset are not being updated when there is no change in the template nor parameters, thereby drastically reducing the overall deployment time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.