### PR TITLE
Added awscli upgrade command

### DIFF
--- a/source/bin/codebuild_scripts/install_stage_dependencies.sh
+++ b/source/bin/codebuild_scripts/install_stage_dependencies.sh
@@ -26,6 +26,7 @@ install_common_pip_packages () {
     pip install --upgrade jinja2
     pip install --upgrade boto3
     pip install --upgrade requests
+    pip install --upgrade awscli
 }
 
 build_dependencies () {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-control-tower-customizations/issues/34

*Description of changes:*

botocore 1.18.0 removed AWS CLI specific doc files. Those were already migrated to the CLI in version 1.18.140. 

install_stage_dependencies upgrades botocore but not awscli which makes them incompatible

This is failing codebuild stage.

Added following awscli upgrade command in install_stage_dependencies.sh

pip install --upgrade pip


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
